### PR TITLE
Preparing for Flux v2.3.0 release

### DIFF
--- a/bicep/modules/blade_service.bicep
+++ b/bicep/modules/blade_service.bicep
@@ -724,7 +724,7 @@ module appConfigMap './aks-config-map/main.bicep' = {
 */
 
 //--------------Flux Config---------------
-module fluxConfiguration 'br/public:avm/res/kubernetes-configuration/flux-configuration:0.3.3' = if(enableSoftwareLoad) {
+module fluxConfiguration 'br/public:avm/res/kubernetes-configuration/flux-configuration:0.3.4' = if(enableSoftwareLoad) {
   name: '${bladeConfig.sectionName}-cluster-gitops'
   params: {
     name: serviceLayerConfig.gitops.name

--- a/software/applications/dev-sample/release.yaml
+++ b/software/applications/dev-sample/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: dev-sample

--- a/software/applications/elastic-search/elastic-job.yaml
+++ b/software/applications/elastic-search/elastic-job.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: elastic-search-init

--- a/software/applications/elastic-search/vault-secrets.yaml
+++ b/software/applications/elastic-search/vault-secrets.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: azure-keyvault-credentials

--- a/software/applications/osdu-auth/release.yaml
+++ b/software/applications/osdu-auth/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: azure-keyvault-credentials
@@ -30,7 +30,7 @@ spec:
           - key: clientSecret
             vaultSecret: app-dev-sp-password
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: osdu-auth

--- a/software/applications/osdu-core/base.yaml
+++ b/software/applications/osdu-core/base.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: osdu-developer-base

--- a/software/applications/osdu-core/entitlements.yaml
+++ b/software/applications/osdu-core/entitlements.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: entitlements
@@ -119,7 +119,7 @@ spec:
         value: "http://partition/api/partition/v1"
 ---
 # Retrigger:  kubectl annotate helmrelease osdu-init-entitlements fluxcd.io/retrigger=$(date +%s) -n osdu-core
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: osdu-init-entitlements

--- a/software/applications/osdu-core/file.yaml
+++ b/software/applications/osdu-core/file.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: file

--- a/software/applications/osdu-core/indexer.yaml
+++ b/software/applications/osdu-core/indexer.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: indexer-service
@@ -137,7 +137,7 @@ spec:
       - name: SEARCH_SERVICE_URL
         value: http://search/api/search/v2
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: indexer-queue

--- a/software/applications/osdu-core/legal.yaml
+++ b/software/applications/osdu-core/legal.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: legal

--- a/software/applications/osdu-core/partition.yaml
+++ b/software/applications/osdu-core/partition.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: partition
@@ -109,7 +109,7 @@ spec:
             value: "DEBUG"
 ---
 # Retrigger:  kubectl annotate helmrelease osdu-init-partition fluxcd.io/retrigger=$(date +%s) -n osdu-core
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: osdu-init-partition

--- a/software/applications/osdu-core/schema.yaml
+++ b/software/applications/osdu-core/schema.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: schema
@@ -123,7 +123,7 @@ spec:
       - name: ENTITLEMENTS_SERVICE_API_KEY
         value: "OBSOLETE"
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: osdu-init-schema

--- a/software/applications/osdu-core/search.yaml
+++ b/software/applications/osdu-core/search.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: search

--- a/software/applications/osdu-core/storage.yaml
+++ b/software/applications/osdu-core/storage.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: storage

--- a/software/applications/osdu-core/user-init.yaml
+++ b/software/applications/osdu-core/user-init.yaml
@@ -1,6 +1,6 @@
 ---
 # kubectl create job --namespace osdu-core --from=cronjob/user-init user-init-run-$(date +%s)
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: osdu-init-users

--- a/software/applications/podinfo/release.yaml
+++ b/software/applications/podinfo/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo

--- a/software/components/cache/release.yaml
+++ b/software/components/cache/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: azure-keyvault-cache
@@ -30,7 +30,7 @@ spec:
           - key: redis-password
             vaultSecret: redis-password
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: redis

--- a/software/components/certs/release.yaml
+++ b/software/components/certs/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: cert-manager

--- a/software/components/configmap/release.yaml
+++ b/software/components/configmap/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: config-maps

--- a/software/components/elastic/release.yaml
+++ b/software/components/elastic/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: elastic-operator

--- a/software/components/mesh/release.yaml
+++ b/software/components/mesh/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: istio-base
@@ -21,7 +21,7 @@ spec:
   values:
     defaultRevision: default
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: cert-manager-istio-csr
@@ -52,7 +52,7 @@ spec:
           kind: ClusterIssuer
           group: cert-manager.io
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: istiod
@@ -91,7 +91,7 @@ spec:
         K8S_INGRESS_NS: istio-ingress
         ENABLE_NATIVE_SIDECARS: true
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: istio-ingress-internal
@@ -132,7 +132,7 @@ spec:
         annotations: 
           service.beta.kubernetes.io/azure-load-balancer-internal: 'true'
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: istio-ingress-external


### PR DESCRIPTION
Current Flux Extension is 1.10.0.  Next update should deprecate a flux API so moving to the updated released API for HelmRelease.