### PR TITLE
This is a change to allow for App Configuration Provider 2.0

### DIFF
--- a/charts/config-maps/templates/config-map-software.yaml
+++ b/charts/config-maps/templates/config-map-software.yaml
@@ -15,7 +15,6 @@ spec:
   auth:
     workloadIdentity:
       serviceAccountName: workload-identity-sa
-      # managedIdentityClientId: {{ .Values.azure.clientId }}
   configuration:
     selectors:
       - keyFilter: "*"

--- a/charts/config-maps/templates/config-map-software.yaml
+++ b/charts/config-maps/templates/config-map-software.yaml
@@ -14,7 +14,8 @@ spec:
       separator: "."
   auth:
     workloadIdentity:
-      managedIdentityClientId: {{ .Values.azure.clientId }}
+      serviceAccountName: workload-identity-sa
+      # managedIdentityClientId: {{ .Values.azure.clientId }}
   configuration:
     selectors:
       - keyFilter: "*"

--- a/charts/osdu-developer-base/templates/config-map-services.yaml
+++ b/charts/osdu-developer-base/templates/config-map-services.yaml
@@ -10,7 +10,8 @@ spec:
     configMapName: configmap-services
   auth:
     workloadIdentity:
-      managedIdentityClientId: {{ .Values.azure.clientId }}
+      serviceAccountName: workload-identity-sa
+      # managedIdentityClientId: {{ .Values.azure.clientId }}
   configuration:
      selectors:
         - keyFilter: "*"

--- a/charts/osdu-developer-base/templates/config-map-services.yaml
+++ b/charts/osdu-developer-base/templates/config-map-services.yaml
@@ -11,7 +11,6 @@ spec:
   auth:
     workloadIdentity:
       serviceAccountName: workload-identity-sa
-      # managedIdentityClientId: {{ .Values.azure.clientId }}
   configuration:
      selectors:
         - keyFilter: "*"

--- a/charts/osdu-developer-base/templates/config-map-software.yaml
+++ b/charts/osdu-developer-base/templates/config-map-software.yaml
@@ -15,7 +15,6 @@ spec:
   auth:
     workloadIdentity:
       serviceAccountName: workload-identity-sa
-      # managedIdentityClientId: {{ .Values.azure.clientId }}
   configuration:
     selectors:
       - keyFilter: "*"

--- a/charts/osdu-developer-base/templates/config-map-software.yaml
+++ b/charts/osdu-developer-base/templates/config-map-software.yaml
@@ -14,7 +14,8 @@ spec:
       separator: "."
   auth:
     workloadIdentity:
-      managedIdentityClientId: {{ .Values.azure.clientId }}
+      serviceAccountName: workload-identity-sa
+      # managedIdentityClientId: {{ .Values.azure.clientId }}
   configuration:
     selectors:
       - keyFilter: "*"

--- a/charts/osdu-developer-base/templates/config-map-values.yaml
+++ b/charts/osdu-developer-base/templates/config-map-values.yaml
@@ -14,7 +14,8 @@ spec:
       separator: "."
   auth:
     workloadIdentity:
-      managedIdentityClientId: {{ .Values.azure.clientId }}
+      serviceAccountName: workload-identity-sa
+      # managedIdentityClientId: {{ .Values.azure.clientId }}
   configuration:
      selectors:
         - keyFilter: "*"

--- a/charts/osdu-developer-base/templates/config-map-values.yaml
+++ b/charts/osdu-developer-base/templates/config-map-values.yaml
@@ -15,7 +15,6 @@ spec:
   auth:
     workloadIdentity:
       serviceAccountName: workload-identity-sa
-      # managedIdentityClientId: {{ .Values.azure.clientId }}
   configuration:
      selectors:
         - keyFilter: "*"


### PR DESCRIPTION
The change in 2.0 provider requires this as noted here. https://learn.microsoft.com/en-us/azure/azure-app-configuration/quickstart-azure-kubernetes-service#why-am-i-unable-to-authenticate-with-azure-app-configuration-using-workload-identity-after-upgrading-the-provider-to-version-200